### PR TITLE
Set _d parameter if using cron

### DIFF
--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -189,7 +189,7 @@ class KMTS
       query     = ''
       data.update('_p' => id) if id
       data.update('_k' => @key)
-      data.update '_d' => 1 if data['_t']
+      data.update '_d' => 1 if data['_t']  || @use_cron
       data['_t'] ||= Time.now.to_i
       
       unsafe = Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N')


### PR DESCRIPTION
If using cron, the generated requests won't be submitted to the tracking servers until past the time they actually occurred. Because of this, we should honor the timestamp that is generated at the time the event happened, not *at the time of event submission*.