### PR TITLE
Sjw/timestamp validation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,5 @@ require 'rspec/core/rake_task'
 Bundler::GemHelper.install_tasks
 
 RSpec::Core::RakeTask.new(:spec)
+
+task :default => [:spec]

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -191,13 +191,19 @@ class KMTS
       data.update('_k' => @key)
       data.update '_d' => 1 if data['_t']
       data['_t'] ||= Time.now.to_i
-      
+
       unsafe = Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N')
       
       data.inject(query) do |query,key_val|
         query_arr <<  key_val.collect { |i| URI.escape(i.to_s, unsafe) }.join('=')
       end
       query = '/' + type + '?' + query_arr.join('&')
+
+      unless data['_t'].to_s =~ /\d{10}/ and data['_t'].to_i >= 0
+        log_query(query)
+        log_error("#{data['_t']} is not a valid unix timestamp")
+      end
+
       if @use_cron
         log_query(query)
       else

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -200,12 +200,13 @@ class KMTS
       query = '/' + type + '?' + query_arr.join('&')
 
       begin
-        unless data['_t'].to_s =~ /\d{10}/ and data['_t'].to_i >= 0
+        unless data['_t'].to_s =~ /\A\d+\z/ && data['_t'].to_i >= 0
           raise StandardError, "#{data['_t']} is not a valid unix timestamp"
         end
       rescue StandardError => e
         log_query(query)
         log_error(e)
+        return
       end
 
       if @use_cron

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -199,9 +199,13 @@ class KMTS
       end
       query = '/' + type + '?' + query_arr.join('&')
 
-      unless data['_t'].to_s =~ /\d{10}/ and data['_t'].to_i >= 0
+      begin
+        unless data['_t'].to_s =~ /\d{10}/ and data['_t'].to_i >= 0
+          raise StandardError, "#{data['_t']} is not a valid unix timestamp"
+        end
+      rescue Exception => e
         log_query(query)
-        log_error("#{data['_t']} is not a valid unix timestamp")
+        log_error(e)
       end
 
       if @use_cron

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -203,7 +203,7 @@ class KMTS
         unless data['_t'].to_s =~ /\d{10}/ and data['_t'].to_i >= 0
           raise StandardError, "#{data['_t']} is not a valid unix timestamp"
         end
-      rescue Exception => e
+      rescue StandardError => e
         log_query(query)
         log_error(e)
       end

--- a/spec/km_spec.rb
+++ b/spec/km_spec.rb
@@ -18,6 +18,26 @@ describe KMTS do
     IO.readlines(KMTS::log_name(:error)).join.should =~ /Need to initialize first \(KMTS::init <your_key>\)/
   end
 
+  describe "timstamp" do
+    it "should fail if timestamp is not unix" do
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
+      KMTS::record 'bob', 'Signup', 'age' => 26, '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else', '_t' => 'bad_timestamp'
+      IO.readlines(KMTS::log_name(:error)) =~ /is not a valid unix timestamp/
+    end
+
+    it "should fail if timestamp is not valid unix" do
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
+      KMTS::record 'bob', 'Signup', 'age' => 26, '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else', '_t' => -0000000001
+      IO.readlines(KMTS::log_name(:error)) =~ /is not a valid unix timestamp/
+    end
+
+    it "should succeed if timestamp is valid unix" do
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
+      KMTS::record 'bob', 'Signup', 'age' => 26, '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else', '_t' => 1234567890
+      File.exists?(KMTS::log_name(:error)).should == false
+    end
+  end
+
   it "shouldn't fail on alias without identifying" do
     KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
     KMTS::alias 'peter','joe' # Alias "bob" to "robert"


### PR DESCRIPTION
Adds validation to `_t` values, ensuring that the values are valid unix timestamps.