### PR TITLE
Warn instead of error on not initialized

### DIFF
--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -234,7 +234,7 @@ class KMTS
     end
 
     def is_initialized?
-      return true if @key.present?
+      return true unless @key.nil?
       log(:warn, "Need to initialize first (KMTS::init <your_key>)")
       false
     end

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -234,11 +234,9 @@ class KMTS
     end
 
     def is_initialized?
-      if @key == nil
-        log(:warn, "Need to initialize first (KMTS::init <your_key>)")
-        return false
-      end
-      return true
+      return true if @key.present?
+      log(:warn, "Need to initialize first (KMTS::init <your_key>)")
+      false
     end
     # :startdoc:
   end

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -235,7 +235,7 @@ class KMTS
 
     def is_initialized?
       if @key == nil
-        log_error InitError.new("Need to initialize first (KMTS::init <your_key>)")
+        log(:warn, "Need to initialize first (KMTS::init <your_key>)")
         return false
       end
       return true


### PR DESCRIPTION
How would I otherwise turn this off for test environment. I don't want to make expensive calls to external services during testing.