### PR TITLE
KMTS Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - 2.3.1
+  - 2.2
+  - 2.1
+  - 2.0
+cache:
+  bundler: true
+sudo: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,11 +27,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.0.0)
-  json
+  bundler (~> 1.13)
+  json (~> 2.0)
   kmts!
-  rake
-  rspec
+  rake (~> 12.0)
+  rspec (~> 3.5)
 
 BUNDLED WITH
    1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,17 +6,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
-    json (1.5.1)
-    rake (0.8.7)
-    rspec (2.4.0)
-      rspec-core (~> 2.4.0)
-      rspec-expectations (~> 2.4.0)
-      rspec-mocks (~> 2.4.0)
-    rspec-core (2.4.0)
-    rspec-expectations (2.4.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.4.0)
+    diff-lcs (1.2.5)
+    json (2.0.2)
+    rake (12.0.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -26,4 +31,7 @@ DEPENDENCIES
   json
   kmts!
   rake
-  rspec (~> 2.4.0)
+  rspec
+
+BUNDLED WITH
+   1.13.7

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,10 @@
 require 'bundler'
-require 'rspec/core/rake_task'
 Bundler::GemHelper.install_tasks
 
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
+task default: 'spec'

--- a/kmts.gemspec
+++ b/kmts.gemspec
@@ -5,19 +5,20 @@ Gem::Specification.new do |s|
   s.name        = "kmts"
   s.version     = KMTS::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["KISSmetrics"]
+  s.license     = "Apache-2.0"
+  s.authors     = ["Kissmetrics"]
   s.email       = ["support@kissmetrics.com"]
   s.homepage    = "https://github.com/kissmetrics/kmts"
-  s.summary     = "KISSmetrics threadsafe ruby API gem"
-  s.description = "KISSmetrics threadsafe ruby API gem"
+  s.summary     = "Threadsafe Ruby gem for Kissmetrics tracking API"
+  s.description = "A threadsafe Ruby gem that can be used to interact with the Kissmetrics tracking API."
 
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "kissmetrics"
 
-  s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "json"
+  s.add_development_dependency "bundler", "~> 1.13"
+  s.add_development_dependency "rspec", "~> 3.5"
+  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "json", "~> 2.0"
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/kmts.gemspec
+++ b/kmts.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "kissmetrics"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "rspec", "~> 2.4.0"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
   s.add_development_dependency "json"
 

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -15,7 +15,7 @@ class KMTS
   @host      = DEFAULT_TRACKING_SERVER
   @log_dir   = '/tmp'
   @to_stderr = true
-  @use_cron  = false
+  @use_cron  = true
   @dryrun    = false
 
   class << self

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -7,9 +7,12 @@ require 'kmts/saas'
 class KMError < StandardError; end
 
 class KMTS
+  DEFAULT_TRACKING_SERVER = 'https://trk.kissmetrics.com'.freeze
+  PROTOCOL_MATCHER = %r(://)
+
   @key       = nil
   @logs      = {}
-  @host      = 'trk.kissmetrics.com:80'
+  @host      = DEFAULT_TRACKING_SERVER
   @log_dir   = '/tmp'
   @to_stderr = true
   @use_cron  = false
@@ -121,7 +124,7 @@ class KMTS
       @id         = nil
       @key        = nil
       @logs       = {}
-      @host       = 'trk.kissmetrics.com:80'
+      @host       = DEFAULT_TRACKING_SERVER
       @log_dir    = '/tmp'
       @to_stderr  = true
       @use_cron   = false
@@ -191,9 +194,9 @@ class KMTS
       data.update('_k' => @key)
       data.update '_d' => 1 if data['_t']
       data['_t'] ||= Time.now.to_i
-      
+
       unsafe = Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N')
-      
+
       data.inject(query) do |query,key_val|
         query_arr <<  key_val.collect { |i| URI.escape(i.to_s, unsafe) }.join('=')
       end
@@ -215,11 +218,13 @@ class KMTS
         log_sent(line)
       else
         begin
-          host,port = @host.split(':')
-          proxy = URI.parse(ENV['http_proxy'] || ENV['HTTP_PROXY'] || '')
-          res = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).start(host, port) do |http|
-            http.get(line)
-          end
+          host = @host
+          host = "http://#{host}" unless host =~ PROTOCOL_MATCHER
+          uri = URI.parse(host)
+
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = uri.is_a?(URI::HTTPS)
+          http.get(line)
         rescue Exception => e
           raise KMError.new("#{e} for host #{@host}")
         end

--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -192,7 +192,7 @@ class KMTS
       query     = ''
       data.update('_p' => id) if id
       data.update('_k' => @key)
-      data.update '_d' => 1 if data['_t']
+      data.update '_d' => 1 if data['_t'] || @use_cron
       data['_t'] ||= Time.now.to_i
 
       unsafe = Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N')

--- a/spec/accept.rb
+++ b/spec/accept.rb
@@ -17,7 +17,7 @@ class Accept
 
     puts "Starting up server on port #{opts[:port]} ..."
     @opts           = opts
-    @server         = TCPServer.new(opts[:port])
+    @server         = TCPServer.new('127.0.0.1', opts[:port])
     @@input_history = []
     @handle         = Thread.start do
       loop do

--- a/spec/km_old.rb
+++ b/spec/km_old.rb
@@ -2,15 +2,15 @@ require 'setup'
 
 describe KMTS do
   attr_accessor :send_query, :log
+
   before do
     @send_query = []
     @log = []
     KMTS.stub(:send_query).and_return { |*args| send_query << args }
     KMTS.stub(:log).and_return { |*args| log << Hash[*args] }
-    time = Time.at 1234567890
-    Time.stub!(:now).and_return(time)
     KMTS.reset
   end
+
   context "initialization" do
     it "should not record without initialization" do
       KMTS::record 'My Action'

--- a/spec/km_saas_spec.rb
+++ b/spec/km_saas_spec.rb
@@ -10,7 +10,7 @@ describe KMTS do
 
   describe "should record events" do
     before do
-      KMTS::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292'
+      KMTS::init 'KM_KEY', :log_dir => __('log'), :host => 'http://127.0.0.1:9292'
     end
     context "plain usage" do
       it "records a signup event" do

--- a/spec/km_saas_spec.rb
+++ b/spec/km_saas_spec.rb
@@ -3,8 +3,6 @@ require 'kmts/saas'
 describe KMTS do
   before do
     KMTS::reset
-    now = Time.now
-    Time.stub!(:now).and_return(now)
     FileUtils.rm_f KMTS::log_name(:error)
     FileUtils.rm_f KMTS::log_name(:query)
     Helper.clear

--- a/spec/km_send_spec.rb
+++ b/spec/km_send_spec.rb
@@ -13,11 +13,11 @@ describe 'km_send' do
 
     context "with default environment" do
       before do
-        KMTS::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true, :env => 'production'
+        KMTS::init 'KM_KEY', :log_dir => __('log'), :host => 'http://127.0.0.1:9292', :use_cron => true, :env => 'production'
       end
       it "should test commandline version" do
         KMTS::record 'bob', 'Signup', 'age' => 26
-        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        `bundle exec km_send #{__('log/')} http://127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -29,7 +29,7 @@ describe 'km_send' do
       end
       it "should send from query_log" do
         write_log :query, "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26"
-        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        `bundle exec km_send #{__('log/')} http://127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -41,7 +41,7 @@ describe 'km_send' do
       end
       it "should send from query_log_old" do
         write_log :query_old, "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26"
-        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        `bundle exec km_send #{__('log/')} http://127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -54,7 +54,7 @@ describe 'km_send' do
       it "should send from both query_log and query_log_old" do
         File.open(__('log/kissmetrics_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=27" }
         File.open(__('log/kissmetrics_production_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26" }
-        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        `bundle exec km_send #{__('log/')} http://127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -64,7 +64,7 @@ describe 'km_send' do
         res[:query]['_t'].first.should == '1297105499'
         res[:query]['age'].first.should == '27'
         Helper.clear
-        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        `bundle exec km_send #{__('log/')} http://127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -76,15 +76,15 @@ describe 'km_send' do
       end
       it "sends unless dryrun is specified" do
         File.open(__('log/kissmetrics_alpha_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26" }
-        `bundle exec km_send -e alpha #{__('log/')} 127.0.0.1:9292`
+        `bundle exec km_send -e alpha #{__('log/')} http://127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.should_not be_nil
       end
     end
     it "should send from diff environment when force flag is used" do
-      KMTS::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true, :env => 'development', :force => true
+      KMTS::init 'KM_KEY', :log_dir => __('log'), :host => 'http://127.0.0.1:9292', :use_cron => true, :env => 'development', :force => true
       KMTS::record 'bob', 'Signup', 'age' => 26
-      `bundle exec km_send -f -e development #{__('log/')} 127.0.0.1:9292`
+      `bundle exec km_send -f -e development #{__('log/')} http://127.0.0.1:9292`
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'

--- a/spec/km_send_spec.rb
+++ b/spec/km_send_spec.rb
@@ -4,16 +4,16 @@ describe 'km_send' do
   context "using cron for sending logs" do
     before do
       now = Time.now
-      Time.stub!(:now).and_return(now)
       Dir.glob(__('log','*')).each do |file|
         FileUtils.rm file
       end
       KMTS.reset
       Helper.clear
     end
+
     context "with default environment" do
       before do
-        KMTS::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true
+        KMTS::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true, :env => 'production'
       end
       it "should test commandline version" do
         KMTS::record 'bob', 'Signup', 'age' => 26
@@ -24,7 +24,7 @@ describe 'km_send' do
         res[:query]['_k'].first.should == 'KM_KEY'
         res[:query]['_p'].first.should == 'bob'
         res[:query]['_n'].first.should == 'Signup'
-        res[:query]['_t'].first.should == Time.now.to_i.to_s
+        res[:query]['_t'].first.to_i.should be_within(10.0).of(Time.now.to_i)
         res[:query]['age'].first.should == '26'
       end
       it "should send from query_log" do
@@ -91,7 +91,7 @@ describe 'km_send' do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(10.0).of(Time.now.to_i)
       res[:query]['age'].first.should == '26'
     end
   end

--- a/spec/km_send_spec.rb
+++ b/spec/km_send_spec.rb
@@ -24,6 +24,7 @@ describe 'km_send' do
         res[:query]['_k'].first.should == 'KM_KEY'
         res[:query]['_p'].first.should == 'bob'
         res[:query]['_n'].first.should == 'Signup'
+        res[:query]['_d'].first.should == '1'
         res[:query]['_t'].first.to_i.should be_within(10.0).of(Time.now.to_i)
         res[:query]['age'].first.should == '26'
       end
@@ -91,6 +92,7 @@ describe 'km_send' do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
+      res[:query]['_d'].first.should == '1'
       res[:query]['_t'].first.to_i.should be_within(10.0).of(Time.now.to_i)
       res[:query]['age'].first.should == '26'
     end

--- a/spec/km_spec.rb
+++ b/spec/km_spec.rb
@@ -2,8 +2,6 @@ require 'setup'
 describe KMTS do
   before do
     KMTS::reset
-    now = Time.now
-    Time.stub!(:now).and_return(now)
     FileUtils.rm_f KMTS::log_name(:error)
     FileUtils.rm_f KMTS::log_name(:query)
     Helper.clear
@@ -27,7 +25,7 @@ describe KMTS do
     res[:query]['_k'].first.should == 'KM_OTHER'
     res[:query]['_p'].first.should == 'peter'
     res[:query]['_n'].first.should == 'joe'
-    res[:query]['_t'].first.should == Time.now.to_i.to_s
+    res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
   end
 
   it "shouldn't fail on alias without identifying from commandline" do
@@ -39,7 +37,7 @@ describe KMTS do
     res[:query]['_k'].first.should == 'KM_OTHER'
     res[:query]['_p'].first.should == 'peter'
     res[:query]['_n'].first.should == 'joe'
-    res[:query]['_t'].first.should == Time.now.to_i.to_s
+    res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
   end
 
   describe "should record events" do
@@ -54,7 +52,7 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'My Action'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
     end
     it "records an action with properties" do
       KMTS::record 'bob', 'Signup', 'age' => 26
@@ -64,7 +62,7 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 26.to_s
     end
     it "should be able to hace spaces in key and value" do
@@ -75,7 +73,7 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 26.to_s
       res[:query]['city of residence'].first.should == 'eug ene'
     end
@@ -87,7 +85,7 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 26.to_s
     end
     it "should work with propps using @" do
@@ -97,7 +95,7 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['email'].first.should == 'test@blah.com'
     end
     it "should just set properties without event" do
@@ -107,7 +105,7 @@ describe KMTS do
       res[:path].should == '/s'
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 26.to_s
     end
     it "should be able to use km set directly" do
@@ -117,7 +115,7 @@ describe KMTS do
       res[:path].should == '/s'
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 26.to_s
     end
     it "should work with multiple lines" do
@@ -131,13 +129,13 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
       res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 26.to_s
       res = Helper.accept(:history)[1].indifferent
       res[:path].should == '/e'
       res[:query]['_k'].first.should == 'KM_KEY'
       res[:query]['_p'].first.should == 'bob'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
       res[:query]['age'].first.should == 36.to_s
     end
     it "should not have key hardcoded anywhere" do
@@ -149,7 +147,7 @@ describe KMTS do
       res[:query]['_k'].first.should == 'KM_OTHER'
       res[:query]['_p'].first.should == 'truman'
       res[:query]['_n'].first.should == 'harry'
-      res[:query]['_t'].first.should == Time.now.to_i.to_s
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
     end
   end
   context "reading from files" do
@@ -160,7 +158,7 @@ describe KMTS do
       KMTS.reset
     end
     it "should run fine even though there's no server to connect to" do
-      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9291', :to_stderr => false
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9291', :to_stderr => false, :env => 'production'
       KMTS::record 'bob', 'My Action' # records an action with no action-specific properties;
       Helper.accept(:history).size.should == 0
       File.exists?(__('log/kissmetrics_production_query.log')).should == true

--- a/spec/km_spec.rb
+++ b/spec/km_spec.rb
@@ -17,7 +17,7 @@ describe KMTS do
   end
 
   it "shouldn't fail on alias without identifying" do
-    KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
+    KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => 'http://127.0.0.1:9292'
     KMTS::alias 'peter','joe' # Alias "bob" to "robert"
     sleep 0.1
     res = Helper.accept(:history).first.indifferent
@@ -29,7 +29,7 @@ describe KMTS do
   end
 
   it "shouldn't fail on alias without identifying from commandline" do
-    KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
+    KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => 'http://127.0.0.1:9292'
     KMTS::alias 'peter','joe' # Alias "bob" to "robert"
     sleep 0.1
     res = Helper.accept(:history).first.indifferent
@@ -40,9 +40,17 @@ describe KMTS do
     res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
   end
 
+  it "should allow sending to https endpoints" do
+    lambda do
+      allow(KMTS).to receive(:log_error).and_raise('Error')
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => 'https://trk.kissmetrics.com/'
+      KMTS::record 'bob', 'My Action'
+    end.should_not raise_error
+  end
+
   describe "should record events" do
     before do
-      KMTS::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292'
+      KMTS::init 'KM_KEY', :log_dir => __('log'), :host => 'http://127.0.0.1:9292'
     end
     it "records an action with no action-specific properties" do
       KMTS::record 'bob', 'My Action'
@@ -165,7 +173,7 @@ describe KMTS do
       File.exists?(__('log/kissmetrics_production_error.log')).should == true
     end
     it "should escape @ properly" do
-      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292', :to_stderr => false, :use_cron => true
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :host => 'http://127.0.0.1:9292', :to_stderr => false, :use_cron => true
       KMTS::record 'bob', 'prop_with_@_in' # records an action with no action-specific properties;
       IO.readlines(KMTS::log_name(:query)).join.should_not contain_string('@')
     end

--- a/spec/setup.rb
+++ b/spec/setup.rb
@@ -17,7 +17,7 @@ end
 
 class Helper
   def self.accept(cmd)
-    c = TCPSocket.new('localhost', 9292)
+    c = TCPSocket.new('127.0.0.1', 9292)
     c.puts cmd.to_s
     return JSON.parse(c.read) rescue nil
   end
@@ -75,3 +75,7 @@ def write_log(type, content)
 end
 
 accept = Accept.new
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+end


### PR DESCRIPTION
* Update gem versions
* Run tests on Travis (Ruby versions 2.0, 2.1, 2.2, and 2.3.1)
* Allow `https` endpoints for tracking, and enable `https://trk.kissmetrics.com` as the default endpoint
* Enable the `_d` flag when using cron to ensure correct timestamp tracking
* Fix gemspec warnings
* Enable the cron flag by default. Writing events to a log file and sending them asynchronously is the preferred method for multiple reasons. This is now the default (but can always be disabled).