### PR TITLE
Allow key override, add force_key option

### DIFF
--- a/lib/kmts.rb
+++ b/lib/kmts.rb
@@ -17,6 +17,7 @@ class KMTS
   @to_stderr = true
   @use_cron  = true
   @dryrun    = false
+  @force_key = true
 
   class << self
     class IdentError < StandardError; end
@@ -30,6 +31,7 @@ class KMTS
         :use_cron  => @use_cron,
         :dryrun    => @dryrun,
         :env       => set_env,
+        :force_key => @force_key
       }
       options = default.merge(options)
 
@@ -41,6 +43,7 @@ class KMTS
         @to_stderr = options[:to_stderr]
         @dryrun    = options[:dryrun]
         @env       = options[:env]
+        @force_key = options[:force_key]
         log_dir_writable?
       rescue Exception => e
         log_error(e)
@@ -130,6 +133,7 @@ class KMTS
       @use_cron   = false
       @env        = nil
       @force = false
+      @force_key  = true
     end
 
     def log_name(type)
@@ -191,9 +195,14 @@ class KMTS
       query_arr = []
       query     = ''
       data.update('_p' => id) if id
-      data.update('_k' => @key)
       data.update '_d' => 1 if data['_t'] || @use_cron
       data['_t'] ||= Time.now.to_i
+
+      if @force_key
+        data['_k'] = @key
+      else
+        data['_k'] ||= @key
+      end
 
       unsafe = Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N')
 

--- a/spec/km_spec.rb
+++ b/spec/km_spec.rb
@@ -157,6 +157,34 @@ describe KMTS do
       res[:query]['_n'].first.should == 'harry'
       res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
     end
+
+    it "allows overriding of km_key" do
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :force_key => false
+      KMTS::record 'bob', 'Signup', 'age' => 36, '_k' => 'OTHER_KEY'
+      sleep 0.1
+
+      res = Helper.history.first.indifferent
+      res[:path].should == '/e'
+      res[:query]['_k'].first.should == 'OTHER_KEY'
+      res[:query]['_p'].first.should == 'bob'
+      res[:query]['_n'].first.should == 'Signup'
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
+      res[:query]['age'].first.should == 36.to_s
+    end
+
+    it "uses default key when force_key is disabled" do
+      KMTS::init 'KM_OTHER', :log_dir => __('log'), :force_key => false
+      KMTS::record 'bob', 'Signup', 'age' => 36
+      sleep 0.1
+
+      res = Helper.history.first.indifferent
+      res[:path].should == '/e'
+      res[:query]['_k'].first.should == 'KM_OTHER'
+      res[:query]['_p'].first.should == 'bob'
+      res[:query]['_n'].first.should == 'Signup'
+      res[:query]['_t'].first.to_i.should be_within(2.0).of(Time.now.to_i)
+      res[:query]['age'].first.should == 36.to_s
+    end
   end
   context "reading from files" do
     before do


### PR DESCRIPTION
In some instances, multiple products might be tracked in a single code base (e.g. regional/localized product keys). The current implementation of forcing the `_k` key for all requests remains, but this change allows one to override the `_k` field, and instead pass it in as part of the data for the `record` and `set` methods.