### PR TITLE
add ruby 3.x support, drop support for ruby 2.3 and below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: ruby
 rvm:
-  - 2.3.1
-  - 2.2
-  - 2.1
-  - 2.0
+  - 3.1
+  - 3.0
+  - 2.7
+  - 2.6
+  - 2.5
+  - 2.4
 cache:
   bundler: true
 sudo: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,29 +6,29 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    json (2.0.2)
-    rake (12.0.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    diff-lcs (1.5.0)
+    json (2.6.1)
+    rake (13.0.6)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.13)
-  json (~> 2.0)
+  bundler (~> 2)
+  json (~> 2.6)
   kmts!
-  rake (~> 12.0)
-  rspec (~> 3.5)
+  rake (~> 13)
+  rspec (~> 3)

--- a/kmts.gemspec
+++ b/kmts.gemspec
@@ -13,12 +13,13 @@ Gem::Specification.new do |s|
   s.description = "A threadsafe Ruby gem that can be used to interact with the Kissmetrics tracking API."
 
   s.required_rubygems_version = ">= 1.3.6"
+  s.required_ruby_version     = Gem::Requirement.new(">= 2.4.0")
   s.rubyforge_project         = "kissmetrics"
 
-  s.add_development_dependency "bundler", "~> 1.13"
-  s.add_development_dependency "rspec", "~> 3.5"
-  s.add_development_dependency "rake", "~> 12.0"
-  s.add_development_dependency "json", "~> 2.0"
+  s.add_development_dependency "bundler", "~> 2"
+  s.add_development_dependency "json", "~> 2.6"
+  s.add_development_dependency "rake", "~> 13"
+  s.add_development_dependency "rspec", "~> 3"
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Ruby 3.x has been around for over a year, and Ruby 2.3 has been EOL for three years. This PR adds support for Ruby 3.x while removing support for Ruby 2.3 and below. It's all dependency and CI changes because the code is already compatible with Ruby 3.0 and 3.1.

See [Ruby's official branch maintenance](https://www.ruby-lang.org/en/downloads/branches/) for exact EOL and release dates.